### PR TITLE
Use `paneId` property for x-tab panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,24 +61,24 @@ Example markup:
 
       {{!-- tab content --}}
       <div class="content-wrap">
-        {{#tab.pane elementId="home"}}
+        {{#tab.pane paneId="home"}}
           <h1>Home</h1>
           <p>This is home content</p>
         {{/tab.pane}}
 
-        {{#tab.pane elementId="archive"}}
+        {{#tab.pane paneId="archive"}}
           <h1>Archive</h1>
           <p>This is archive content</p>
         {{/tab.pane}}
-        {{#tab.pane elementId="analytics"}}
+        {{#tab.pane paneId="analytics"}}
           <h1>Analytics</h1>
           <p>This is analytics content</p>
         {{/tab.pane}}
-        {{#tab.pane elementId="settings"}}
+        {{#tab.pane paneId="settings"}}
           <h1>Settings</h1>
           <p>This is settings content</p>
         {{/tab.pane}}
-        {{#tab.pane elementId="upload"}}
+        {{#tab.pane paneId="upload"}}
           <h1>Upload</h1>
           <p>This is upload content</p>
         {{/tab.pane}}

--- a/addon/components/x-tab.js
+++ b/addon/components/x-tab.js
@@ -15,7 +15,7 @@ export default Component.extend(ComponentParent, {
     return view instanceof TabPane;
   }),
 
-  activeId: oneWay('childPanes.firstObject.elementId'),
+  activeId: oneWay('childPanes.firstObject.paneId'),
 
   isActiveId: computed('activeId', {
     get() {
@@ -26,10 +26,10 @@ export default Component.extend(ComponentParent, {
     }
   }),
 
-  navItems: computed('childPanes.@each.{elementId,title,icon}', function() {
+  navItems: computed('childPanes.@each.{paneId,title,icon}', function() {
     let items = A();
     this.get('childPanes').forEach((pane) => {
-      let item = pane.getProperties('elementId', 'title', 'icon');
+      let item = pane.getProperties('paneId', 'title', 'icon');
       items.push(item);
     });
     return items;

--- a/addon/components/x-tab/pane.js
+++ b/addon/components/x-tab/pane.js
@@ -12,12 +12,24 @@ export default Component.extend(ComponentChild, {
 
     activeId: null,
 
-    isActive: computed('activeId', 'elementId', function() {
-        return this.get('activeId') === this.get('elementId');
+    isActive: computed('activeId', 'paneId', function() {
+        return this.get('activeId') === this.get('paneId');
     }).readOnly(),
 
 
     contentCurrent: true,
+
+    _paneId: null,
+    paneId: computed('_paneId', {
+        get() {
+            return this.get('_paneId') || this.get('elementId');
+        },
+
+        set(key, value) {
+            this.set('_paneId', value);
+            return value;
+        }
+    }),
 
     show() {
         this.set('contentCurrent', true);


### PR DESCRIPTION
- Avoid this error thrown by Ember.js 3.13: "Changing a view's elementId after creation is not allowed"

The pane's `paneId` will still fall back to its `elementId` so that automatic selection of the first tab continues to work.