### PR TITLE
Fixed the #with deprecation in ember 3.26+

### DIFF
--- a/addon/templates/components/x-tabs.hbs
+++ b/addon/templates/components/x-tabs.hbs
@@ -1,4 +1,4 @@
-{{#with
+{{#let
   (hash
     selectAction=(action "select")
     registerAction=(action "register")
@@ -15,4 +15,4 @@
       api=api
     )
   }}
-{{/with}}
+{{/let}}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ember-cli-uglify": "^3.0.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",
+    "ember-let-polyfill": "^0.1.0",
     "ember-load-initializers": "^2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4767,6 +4767,14 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
+ember-let-polyfill@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-let-polyfill/-/ember-let-polyfill-0.1.0.tgz#9d37c610441eb41eaaea3a6782bbd4203f5cf0a9"
+  integrity sha512-olLHpS7JnqZcfyYRXcdLATYwDIopKA+ZzI8xswzCIcBYoRgoUJY7E/eW84Unu8ea1jtr/Unx+dQrsU+NrNSoBg==
+  dependencies:
+    ember-cli-babel "^6.16.0"
+    ember-cli-version-checker "^2.1.2"
+
 ember-load-initializers@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-2.0.0.tgz#d4b3108dd14edb0f9dc3735553cc96dadd8a80cb"


### PR DESCRIPTION
Added the let polyfil to maintain 2.18 compatibility. If you are ok with changing the min ember version to 3.2 you can remove the polyfil

https://github.com/rajasegar/ember-x-tabs/issues/42