### PR TITLE
Address getWithDefault deprecation by replacing the function with custom utility

### DIFF
--- a/addon/components/x-tab.js
+++ b/addon/components/x-tab.js
@@ -1,9 +1,10 @@
 import { filter, oneWay } from '@ember/object/computed';
 import Component from '@ember/component';
 import { A } from '@ember/array';
-import { getWithDefault, computed } from '@ember/object';
+import { computed } from '@ember/object';
 import layout from '../templates/components/x-tab';
 import ComponentParent from '../mixins/component-parent';
+import { getWithDefault } from "../utils/get-with-default";
 import TabPane from './x-tab/pane';
 
 export default Component.extend(ComponentParent, {

--- a/addon/utils/get-with-default.js
+++ b/addon/utils/get-with-default.js
@@ -1,0 +1,11 @@
+import { get } from "@ember/object";
+
+function getWithDefault (object, key, defaultValue) {
+  let value = get(object, key);
+  if (value === undefined) {
+    return defaultValue;
+  }
+  return value;
+}
+
+export { getWithDefault }

--- a/tests/unit/utils/get-with-default-test.js
+++ b/tests/unit/utils/get-with-default-test.js
@@ -1,0 +1,21 @@
+import { getWithDefault } from 'ember-x-tabs/utils/get-with-default';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Utils | get with default', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    const person = { 'name': 'my_name' }
+    this.person = person;
+  })
+
+  test('return value if key is present', function(assert) {
+    assert.equal(getWithDefault(this.person, 'name', 'first_name'), 'my_name');
+  });
+
+  test('return default value if key is not present', function(assert) {
+    delete this.person.name;
+    assert.equal(getWithDefault(this.person, 'name', 'first_name'), 'first_name');
+  });
+});


### PR DESCRIPTION
`getWithDefault` has been deprecated in the latest version and this PR attempts to replace the same with the custom built utility and adds a test case for the util.

```Using getWithDefault has been deprecated. Instead, consider using Ember get and explicitly checking for undefined. [deprecation id: ember-metal.get-with-default] See https://deprecations.emberjs.com/v3.x#toc_ember-metal-get-with-default for more details.```