### PR TITLE
Removed tracked from selectFirstTab

### DIFF
--- a/addon/components/x-tabs.js
+++ b/addon/components/x-tabs.js
@@ -12,7 +12,6 @@ export default class XTabsComponent extends Component {
 
   name = "x-tabs";
 
-  @tracked
   selectFirstTab = true;
 
   @action


### PR DESCRIPTION
selectFirstTab is not used in the HBS or any property used by the HBS and does not need reactivity. Decorator `@tracked` is not required on selectFirstTab and removing fixes the issue.

Fixes https://github.com/rajasegar/ember-x-tabs/issues/95